### PR TITLE
fixed docker intructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Developed under the [Open Foris Initiative](https://www.openforis.org)
 ## Where to download the installer?
 
 If you are not interested in the code but rather on the Collect features you might want to run it right away!
-Go to our [website](https://www.openforis.org/tools/collect.html) and download the installer directly there. There are versions for Windows, Mac OS X and Linux 32-bit and 64-bit. 
+Go to our [website](https://openforis.org/solutions/collect/) and download the installer directly there. There are versions for Windows, Mac OS X and Linux 32-bit and 64-bit. 
 
 
 ## Install and run Collect as a Docker container
@@ -31,7 +31,7 @@ Go to our [website](https://www.openforis.org/tools/collect.html) and download t
 
 - [download and install Docker](https://www.docker.com/). Docker is an open platform for developing, shipping, and running applications.
 
-- Create a docker network that the collect application can use to communicate with the database we will create in the next step:
+- Create a docker network that the Collect application can use to communicate with the database we will create in the next step:
 
 ```console
 $ docker network create collect

--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ Go to our [website](https://www.openforis.org/tools/collect.html) and download t
 
 - [download and install Docker](https://www.docker.com/). Docker is an open platform for developing, shipping, and running applications.
 
-- Install a local database (PostgreSQL) as a Docker container. Run this command from command line; it will create also a database named 'arena' and a user 'arena' with password 'arena' and will make the DBMS listen on port 5444 (you can change those parameters as you wish):
+- Create a docker network that the collect application can use to communicate with the database we will create in the next step:
 
 ```console
-$ docker run -d --name collect-db -p 5432:5432 -e POSTGRES_DB=collect -e POSTGRES_PASSWORD=collect123 -e POSTGRES_USER=collect postgis/postgis:12-3.0
+$ docker network create collect
+```
+
+- Install a local database (PostgreSQL) as a Docker container. Run this command from command line; it will create also a database named 'collect' and a user 'collect' with password 'collect123' and will make the DBMS listen on port 5432 (you can change those parameters as you wish):
+
+```console
+$ docker run -d --network=collect --name collect-db -p 127.0.0.1:5432:5432 -e POSTGRES_DB=collect -e POSTGRES_PASSWORD=collect123 -e POSTGRES_USER=collect postgis/postgis:12-3.4
 ```
 You can also use an already existing PostgreSQL database installed in a different way and configure Collect to connect to it.
 
@@ -44,7 +50,7 @@ The file (call it **collect.env**) must be a text file with this content:
 
 ```properties
 COLLECT_DB_DRIVER=org.postgresql.Driver
-COLLECT_DB_URL=jdbc:postgresql://localhost:5432/collect
+COLLECT_DB_URL=jdbc:postgresql://collect-db:5432/collect
 COLLECT_DB_USERNAME=collect
 COLLECT_DB_PASSWORD=collect123
 ```
@@ -53,7 +59,7 @@ COLLECT_DB_PASSWORD=collect123
 Running the following command from command line will install Collect as a Docker container:
 
 ```console
-$ docker run -m 4GB -p 8080:8080 --env-file ./collect.env openforis/collect:latest
+$ docker run -m 4GB --network=collect -p 8080:8080 --env-file ./collect.env openforis/collect:latest
 ```
 You can run this command in the same folder where you have defined the collect.env file or specify its path in the command, in the '--env-file' parameter.
 Collect will start on the port specified in the collect.env file (8080 by default).


### PR DESCRIPTION
I found some mistakes in the the docker instructions, these changes to the README contain correct instructions for getting collect up and running using docker.

The problem was primarily that the collect container was configured to connect to the database on "localhost", but that will not work unless _--network=host_ is also specified when the container is created. The most sane solution is to create a shared network for the database and collect containers and specifying the name of the database container as the hostname in the environment variables as I have done in this pull request.